### PR TITLE
Implemented Full Unit Test Suite for Repositories + Analytics Router

### DIFF
--- a/fullstack_project/backend/UnitTesting/conftest.py
+++ b/fullstack_project/backend/UnitTesting/conftest.py
@@ -1,0 +1,36 @@
+import pytest
+
+@pytest.fixture
+def temp_env(tmp_path, monkeypatch):
+    """
+    Creates isolated temp CSV files and patches DATA_PATH in each repo.
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    fake_users = data_dir / "users.csv"
+    fake_res = data_dir / "book_reservations.csv"
+    fake_books = data_dir / "books.csv"
+    fake_waitlist = data_dir / "waitlist.csv"
+    fake_analytics = data_dir / "analytics.csv"
+
+    # Import repos AFTER creating fake files
+    import app.repositories.users_repo as users_repo
+    import app.repositories.reservations_repo as reservation_repo
+    import app.repositories.books_repo as books_repo
+    import app.repositories.waitlists_repo as waitlists_repo
+    import app.repositories.analytics_repo as analytics_repo
+
+    monkeypatch.setattr(users_repo, "DATA_PATH", fake_users)
+    monkeypatch.setattr(reservation_repo, "DATA_PATH", fake_res)
+    monkeypatch.setattr(books_repo, "DATA_PATH", fake_books)
+    monkeypatch.setattr(waitlists_repo, "DATA_PATH", fake_waitlist)
+    monkeypatch.setattr(analytics_repo, "DATA_PATH", fake_analytics)
+
+    return {
+        "users": fake_users,
+        "reservations": fake_res,
+        "books": fake_books,
+        "waitlist": fake_waitlist,      #  <--- FIXED KEY!!!
+        "analytics": fake_analytics,
+    }

--- a/fullstack_project/backend/UnitTesting/test_analytics_router.py
+++ b/fullstack_project/backend/UnitTesting/test_analytics_router.py
@@ -1,0 +1,129 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from app.core.security import verify_access_token
+from app.services import analytics_service
+from app.repositories import analytics_repo
+
+def override_admin():
+    return {"userid": "admin", "is_admin": True}
+
+def override_user():
+    return {"userid": "u1", "is_admin": False}
+
+
+# GET /analytics
+def test_get_all_analytics_success(temp_env, monkeypatch):
+    app.dependency_overrides[verify_access_token] = override_admin
+
+    monkeypatch.setattr(analytics_repo, "load_all", lambda: [{"id": "1"}])
+
+    client = TestClient(app)
+    res = client.get("/analytics")
+
+    assert res.status_code == 200
+    assert res.json() == [{"id": "1"}]
+
+    app.dependency_overrides = {}
+
+
+def test_get_all_analytics_empty(temp_env, monkeypatch):
+    app.dependency_overrides[verify_access_token] = override_admin
+    monkeypatch.setattr(analytics_repo, "load_all", lambda: [])
+
+    client = TestClient(app)
+    res = client.get("/analytics")
+
+    assert res.status_code == 404
+    app.dependency_overrides = {}
+
+
+# POST /analytics/rebuild
+def test_rebuild_analytics_success(monkeypatch):
+    app.dependency_overrides[verify_access_token] = override_admin
+    monkeypatch.setattr(analytics_service, "rebuild_analytics", lambda: None)
+
+    client = TestClient(app)
+    res = client.post("/analytics/rebuild")
+
+    assert res.status_code == 200
+
+    app.dependency_overrides = {}
+
+
+def test_rebuild_analytics_requires_admin():
+    app.dependency_overrides[verify_access_token] = override_user
+
+    client = TestClient(app)
+    res = client.post("/analytics/rebuild")
+
+    assert res.status_code == 403
+
+    app.dependency_overrides = {}
+
+
+# DELETE /analytics
+def test_delete_analytics_success(monkeypatch):
+    app.dependency_overrides[verify_access_token] = override_admin
+    monkeypatch.setattr(analytics_repo, "save_all", lambda x: None)
+
+    client = TestClient(app)
+    res = client.delete("/analytics")
+
+    assert res.status_code == 204
+
+    app.dependency_overrides = {}
+
+
+# GET /analytics/top-rated
+def test_top_rated_books(monkeypatch):
+    app.dependency_overrides[verify_access_token] = override_admin
+    monkeypatch.setattr(analytics_service.get_top_rated_books, "__call__", lambda n: [{"isbn": "111"}])
+
+    monkeypatch.setattr(analytics_service, "get_top_rated_books", lambda n: [{"isbn": "111"}])
+
+    client = TestClient(app)
+    res = client.get("/analytics/top-rated?n=5")
+
+    assert res.status_code == 200
+    assert res.json() == [{"isbn": "111"}]
+
+    app.dependency_overrides = {}
+
+
+# GET /analytics/trending
+def test_trending_requires_admin():
+    app.dependency_overrides[verify_access_token] = override_user
+
+    client = TestClient(app)
+    res = client.get("/analytics/trending")
+
+    assert res.status_code == 403
+
+    app.dependency_overrides = {}
+
+
+def test_trending_success(monkeypatch):
+    app.dependency_overrides[verify_access_token] = override_admin
+    monkeypatch.setattr(analytics_service, "get_trending_books", lambda n: [{"isbn": "123"}])
+
+    client = TestClient(app)
+    res = client.get("/analytics/trending?n=3")
+
+    assert res.status_code == 200
+    assert res.json() == [{"isbn": "123"}]
+
+    app.dependency_overrides = {}
+
+
+# GET /analytics/genres
+def test_genres_success(monkeypatch):
+    app.dependency_overrides[verify_access_token] = override_admin
+    monkeypatch.setattr(analytics_service, "get_genre_popularity", lambda: {"fantasy": 100})
+
+    client = TestClient(app)
+    res = client.get("/analytics/genres")
+
+    assert res.status_code == 200
+    assert res.json() == {"fantasy": 100}
+
+    app.dependency_overrides = {}

--- a/fullstack_project/backend/UnitTesting/test_books_repo.py
+++ b/fullstack_project/backend/UnitTesting/test_books_repo.py
@@ -1,0 +1,20 @@
+from app.repositories import books_repo
+
+def test_books_empty(temp_env):
+    assert books_repo.load_all() == []
+
+def test_books_write_and_load(temp_env):
+    rows = [
+        {"isbn": "123", "title": "Dune"},
+        {"isbn": "456", "title": "1984"},
+    ]
+
+    books_repo.save_all(rows)
+    loaded = books_repo.load_all()
+
+    assert loaded == rows
+
+def test_books_delete_file_on_empty(temp_env):
+    books_repo.save_all([])
+
+    assert not temp_env["books"].exists()

--- a/fullstack_project/backend/UnitTesting/test_reservations_repo.py
+++ b/fullstack_project/backend/UnitTesting/test_reservations_repo.py
@@ -1,0 +1,19 @@
+from app.repositories import reservations_repo
+
+def test_reservations_empty(temp_env):
+    assert reservations_repo.load_all() == []
+
+def test_reservation_write_and_load(temp_env):
+    rows = [
+        {"res_id": "1", "user": "u1", "isbn": "111"},
+        {"res_id": "2", "user": "u2", "isbn": "222"},
+    ]
+
+    reservations_repo.save_all(rows)
+    loaded = reservations_repo.load_all()
+
+    assert loaded == rows
+
+def test_reservations_delete_on_empty(temp_env):
+    reservations_repo.save_all([])
+    assert not temp_env["reservations"].exists()

--- a/fullstack_project/backend/UnitTesting/test_users_repo.py
+++ b/fullstack_project/backend/UnitTesting/test_users_repo.py
@@ -1,0 +1,21 @@
+from app.repositories import users_repo
+
+def test_users_load_empty(temp_env):
+    assert users_repo.load_all() == []
+
+def test_users_save_and_reload(temp_env):
+    users = [
+        {"id": "u1", "name": "Ahab"},
+        {"id": "u2", "name": "Qamar"}
+    ]
+
+    users_repo.save_all(users)
+
+    loaded = users_repo.load_all()
+    assert loaded == users
+
+def test_users_save_empty_deletes_file(temp_env):
+    users_repo.save_all([])
+
+    # File should not exist
+    assert not temp_env["users"].exists()

--- a/fullstack_project/backend/UnitTesting/test_waitlist_repo.py
+++ b/fullstack_project/backend/UnitTesting/test_waitlist_repo.py
@@ -1,0 +1,33 @@
+from app.repositories import waitlists_repo
+
+def test_waitlist_load_empty(temp_env):
+    """
+    load_all() should return an empty list if the waitlist.csv file does not exist.
+    """
+    assert waitlists_repo.load_all() == []
+
+
+def test_waitlist_save_and_reload(temp_env):
+    """
+    save_all() should correctly write rows to the CSV file,
+    and load_all() should return the same data.
+    """
+    rows = [
+        {"user_id": "u1", "isbn": "123"},
+        {"user_id": "u2", "isbn": "456"}
+    ]
+
+    waitlists_repo.save_all(rows)
+    loaded = waitlists_repo.load_all()
+
+    assert loaded == rows
+
+
+def test_waitlist_delete_on_empty(temp_env):
+    """
+    Passing an empty list to save_all() should delete the file.
+    """
+    waitlists_repo.save_all([])
+
+    # The file should be removed
+    assert not temp_env["waitlist"].exists()


### PR DESCRIPTION
I added a complete set of unit tests for the backend repositories and analytics API router. The suite uses isolated tmp_path CSV files, mocking of DATA_PATH, and FastAPI dependency overrides to ensure accurate and side-effect-free testing.

Changes:
Added test_users_repo.py
Added test_waitlist_repo.py
Added test_reservations_repo.py
Added test_books_repo.py
Added test_analytics_router.py

Created unified conftest.py with monkeypatch + tmp_path
Ensured DATA_PATH is isolated for every test